### PR TITLE
Fixed the CP_Image_Screenshot function

### DIFF
--- a/Processing_Sample/CProcessing/Source/CP_Image.c
+++ b/Processing_Sample/CProcessing/Source/CP_Image.c
@@ -306,12 +306,23 @@ CP_API CP_Image CP_Image_Screenshot(int x, int y, int w, int h)
 	{
 		return NULL;
 	}
+	CP_CorePtr CORE = GetCPCore();
+
+	// glReadPixles uses x,y as the lower left, so lets convert that
+	// to the top right for the sake of consistency
+	y = (CORE->window_height - h) - y;
+
+	// flush nanovg so image can be captured
+	nvgEndFrame(CORE->nvg);
 
 	glReadPixels(x, y, w, h, GL_RGBA, GL_UNSIGNED_BYTE, buffer);
 
+	nvgBeginFrame(CORE->nvg, CORE->window_width, CORE->window_height, CORE->pixel_ratio);
+
 	int rowWidth = w * 4;
 	int size = h;
-	for (int rowIndex = 0; rowIndex < size / 2; ++rowIndex) // loop through each row
+	
+	for (int rowIndex = 0; rowIndex < (size / 2); ++rowIndex) // loop through each row
 	{
 		unsigned char* rowFront = &buffer[rowIndex * rowWidth];
 		unsigned char* rowBack = &buffer[(h - rowIndex - 1) * rowWidth];


### PR DESCRIPTION
Made two changes to the CP_Image_ScreenShot function.

The issue with only the background being captured has been fixed. This seems to have been caused by what appears to be NanoVG storing the draw calls in a buffer and only drawing everything when nvgEndFrame is called. The nvgEndFrame function is only ever called by CProcessing at the end of the game state loop, during the CP_EndFrame function. ScreenShot relies on a raw OpenGL call (glReadPixels), not a NanoVG one, so basically what was happening was that glReadPixels was working as expected, there just wasn't anything actually drawn on screen at the time of the call because nvgEndFrame hadn't been called yet.

My fix is really simple. Call nvgEndFrame right before glReadPixels and nvgStartFrame immediately after. This allows nanoVG to do it's thing and gives glReadPixels something to capture. Calling nvgStartFrame afterwards allows the user to call additional drawing functions after the screenshot has been taken.

The other change to the function address the disconnect between CProcessing and OpenGL's coordinate systems. CProcessing has the screen origin at the top left, OpenGL has it at the bottom left. This inconsistency may cause some confusion, so a minor conversion has been made so now the function expects the same  upper left origin coordinates as the rest of CProcessing's functions.