### PR TITLE
CP_Graphics_DrawPoint - match DrawLine color, size, and shape

### DIFF
--- a/Processing_Sample/CProcessing/Source/CP_Graphics.c
+++ b/Processing_Sample/CProcessing/Source/CP_Graphics.c
@@ -101,12 +101,12 @@ CP_API void CP_Graphics_DrawPoint(float x, float y)
 	CP_CorePtr CORE = GetCPCore();
 	CP_DrawInfoPtr DI = GetDrawInfo();
 
-	// Point only has fill, no stroke
+	// Point path and fill
 	if (DI->fill)
 	{
 		nvgBeginPath(CORE->nvg);
-		nvgRect(CORE->nvg, x, y, 1.0f, 1.0f);
-		nvgFill(CORE->nvg);
+		nvgPoint(CORE->nvg, x, y);
+		nvgFillPoint(CORE->nvg);
 	}
 }
 

--- a/Processing_Sample/CProcessing/nanovg/src/nanovg.c
+++ b/Processing_Sample/CProcessing/nanovg/src/nanovg.c
@@ -2248,6 +2248,20 @@ void nvgCircle(NVGcontext* ctx, float cx, float cy, float r)
 	nvgEllipse(ctx, cx,cy, r,r);
 }
 
+void nvgPoint(NVGcontext* ctx, float x, float y)
+{
+	NVGstate* state = nvg__getState(ctx);
+	float halfWidth = state->strokeWidth * 0.5f;
+	if (state->lineCap == NVG_ROUND)
+	{
+		nvgCircle(ctx, x + 0.5f, y + 0.5f, halfWidth);
+	}
+	else
+	{
+		nvgRect(ctx, x + 0.5f - halfWidth, y + 0.5f - halfWidth, state->strokeWidth, state->strokeWidth);
+	}
+}
+
 void nvgDebugDumpPathCache(NVGcontext* ctx)
 {
 	const NVGpath* path;
@@ -2270,11 +2284,11 @@ void nvgDebugDumpPathCache(NVGcontext* ctx)
 	}
 }
 
-void nvgFill(NVGcontext* ctx)
+void nvgFillInternal(NVGcontext* ctx, int useStrokePaint)
 {
 	NVGstate* state = nvg__getState(ctx);
 	const NVGpath* path;
-	NVGpaint fillPaint = state->fill;
+	NVGpaint fillPaint = useStrokePaint ? state->stroke : state->fill;
 	int i;
 
 	nvg__flattenPaths(ctx);
@@ -2309,6 +2323,16 @@ void nvgFill(NVGcontext* ctx)
 	}
 }
 
+void nvgFill(NVGcontext* ctx)
+{
+	nvgFillInternal(ctx, 0);
+}
+
+void nvgFillPoint(NVGcontext* ctx)
+{
+	nvgFillInternal(ctx, 1);
+}
+
 void nvgStroke(NVGcontext* ctx)
 {
 	NVGstate* state = nvg__getState(ctx);
@@ -2317,7 +2341,6 @@ void nvgStroke(NVGcontext* ctx)
 	NVGpaint strokePaint = state->stroke;
 	const NVGpath* path;
 	int i;
-	
 	
 	if (strokeWidth < ctx->fringeWidth) {
 		// If the stroke width is less than pixel size, use alpha to emulate coverage.

--- a/Processing_Sample/CProcessing/nanovg/src/nanovg.h
+++ b/Processing_Sample/CProcessing/nanovg/src/nanovg.h
@@ -542,11 +542,17 @@ void nvgEllipse(NVGcontext* ctx, float cx, float cy, float rx, float ry);
 // Creates new circle shaped sub-path.
 void nvgCircle(NVGcontext* ctx, float cx, float cy, float r);
 
+// Creates a rect or circle shaped sub-path based on line cap mode
+void nvgPoint(NVGcontext* ctx, float cx, float cy);
+
 // Fills the current path with current fill style.
 void nvgFill(NVGcontext* ctx);
 
 // Fills the current path with current stroke style.
 void nvgStroke(NVGcontext* ctx);
+
+// Fills the current path with stroke style override.
+void nvgFillPoint(NVGcontext* ctx);
 
 
 //


### PR DESCRIPTION
CP_Graphics_DrawPoint now matches the settings used for DrawLine.

- Stroke color - Points now draw the same color as Lines
- Stoke weight - Point size is now controllable based on stroke weight
- Line cap style - Round line caps make for circle Points, all other cap styles (Butt, Square) make square Points