### PR TITLE
ScreenToWorld bug fix

### DIFF
--- a/Processing_Sample/CProcessing/Source/CP_Input.c
+++ b/Processing_Sample/CProcessing/Source/CP_Input.c
@@ -316,10 +316,11 @@ void CP_Input_WorldMouseUpdate(void)
 	CP_CorePtr CORE = GetCPCore();
 	if (!CORE || !CORE->nvg) return;
 
-	float t[6] = { 0 };
-	nvgCurrentTransform(CORE->nvg, t); // world to screen
-	nvgTransformInverse(t, t);         // screen to world
-	nvgTransformPoint(&_worldMouseX, &_worldMouseY, t, _mouseX, _mouseY);
+	float worldToScreen[6] = { 0 };
+	float screenToWorld[6] = { 0 };
+	nvgCurrentTransform(CORE->nvg, worldToScreen); // world to screen
+	nvgTransformInverse(screenToWorld, worldToScreen);         // screen to world
+	nvgTransformPoint(&_worldMouseX, &_worldMouseY, screenToWorld, _mouseX, _mouseY);
 	_worldMouseIsDirty = FALSE;
 }
 

--- a/Processing_Sample/CProcessing/Source/CP_Math.c
+++ b/Processing_Sample/CProcessing/Source/CP_Math.c
@@ -82,10 +82,11 @@ CP_API void CP_Math_ScreenToWorld(float xIn, float yIn, float* xOut, float* yOut
 		return;
 	}
 
-	float t[6] = { 0 };
-	nvgCurrentTransform(CORE->nvg, t);
-	nvgTransformInverse(t, t); // world to screen -> screen to world
-	nvgTransformPoint(xOut, yOut, t, xIn, yIn);
+	float worldToScreen[6] = { 0 };
+	float screenToWorld[6] = { 0 };
+	nvgCurrentTransform(CORE->nvg, worldToScreen);
+	nvgTransformInverse(screenToWorld, worldToScreen);
+	nvgTransformPoint(xOut, yOut, screenToWorld, xIn, yIn);
 }
 
 CP_API void CP_Math_WorldToScreen(float xIn, float yIn, float* xOut, float* yOut)


### PR DESCRIPTION
ScreenToWorld was altering the input matrix which was causing errors.  This was seen when using a scaling factor.  We corrected the use of the function to have separate input and output data so it doesn't get overridden.