### PR TITLE
CP_Font_Free - add this important asset memory cleanup function

### DIFF
--- a/Processing_Sample/CProcessing/Source/CP_Text.c
+++ b/Processing_Sample/CProcessing/Source/CP_Text.c
@@ -128,6 +128,7 @@ void CP_Text_Shutdown(void)
 		CP_Font font = vect_at_CP_Font(font_vector, i);
 		if (font)
 		{
+			nvgFreeFont(CORE->nvg, font->filepath);
 			free(font);
 		}
 	}

--- a/Processing_Sample/CProcessing/Source/CP_Text.c
+++ b/Processing_Sample/CProcessing/Source/CP_Text.c
@@ -168,6 +168,12 @@ CP_API void CP_Font_Free(CP_Font* font)
 	{
 		if (vect_at_CP_Font(font_vector, i) == *font)
 		{
+			if (i == 0)
+			{
+				// don't allow the unloading of the built-in default font Exo2-Regular.ttf
+				return;
+			}
+
 			// remove the font from the list and also ask NVG to remove and free
 			vect_rem_CP_Font(font_vector, i);
 			nvgFreeFont(CORE->nvg, (*font)->filepath);

--- a/Processing_Sample/CProcessing/Source/CP_Text.c
+++ b/Processing_Sample/CProcessing/Source/CP_Text.c
@@ -149,6 +149,29 @@ CP_API CP_Font CP_Font_Load(const char* filepath)
 	return CP_Font_LoadInternal(filepath, false, NULL, 0, 0);
 }
 
+CP_API void CP_Font_Free(CP_Font* font)
+{
+	if (font == NULL || *font == NULL)
+	{
+		return;
+	}
+
+	// find the font in the list
+	for (unsigned i = 0; i < font_vector->size; ++i)
+	{
+		if (vect_at_CP_Font(font_vector, i) == *font)
+		{
+			// remove the image from the list and place on the free queue
+			vect_rem_CP_Font(font_vector, i);
+			free(*font);
+			*font = NULL;
+			return;
+		}
+	}
+
+	// TODO: handle error - we reached the end of the list without finding the image
+}
+
 CP_API void CP_Font_Set(CP_Font font)
 {
 	CP_CorePtr CORE = GetCPCore();

--- a/Processing_Sample/CProcessing/Source/CP_Text.c
+++ b/Processing_Sample/CProcessing/Source/CP_Text.c
@@ -156,13 +156,20 @@ CP_API void CP_Font_Free(CP_Font* font)
 		return;
 	}
 
+	CP_CorePtr CORE = GetCPCore();
+	if (!CORE || !CORE->nvg)
+	{
+		return;
+	}
+
 	// find the font in the list
 	for (unsigned i = 0; i < font_vector->size; ++i)
 	{
 		if (vect_at_CP_Font(font_vector, i) == *font)
 		{
-			// remove the image from the list and place on the free queue
+			// remove the font from the list and also ask NVG to remove and free
 			vect_rem_CP_Font(font_vector, i);
+			nvgFreeFont(CORE->nvg, (*font)->filepath);
 			free(*font);
 			*font = NULL;
 			return;

--- a/Processing_Sample/CProcessing/inc/cprocessing.h
+++ b/Processing_Sample/CProcessing/inc/cprocessing.h
@@ -190,6 +190,7 @@ CP_API float			CP_Sound_GetGroupPitch				(CP_SOUND_GROUP group);
 //		All functions related to loading and drawing fonts
 CP_API CP_Font			CP_Font_GetDefault					(void);
 CP_API CP_Font			CP_Font_Load						(const char* filepath);
+CP_API void				CP_Font_Free						(CP_Font* font);
 CP_API void				CP_Font_Set							(CP_Font font);
 CP_API void				CP_Font_DrawText					(const char* text, float x, float y);
 CP_API void				CP_Font_DrawTextBox					(const char* text, float x, float y, float rowWidth);

--- a/Processing_Sample/CProcessing/nanovg/src/fontstash.h
+++ b/Processing_Sample/CProcessing/nanovg/src/fontstash.h
@@ -876,6 +876,24 @@ error:
 	return FONS_INVALID;
 }
 
+static FONSfont* fons__remFont(FONScontext* stash, const char* name)
+{
+	int idx = fonsGetFontByName(stash, name);
+
+	if (idx == FONS_INVALID)
+		return NULL;
+
+	FONSfont* font = stash->fonts[idx];
+
+	FONSfont* dest = (FONSfont*)stash->fonts + (sizeof(FONSfont*) * idx);
+	FONSfont* src = dest + sizeof(FONSfont*);
+	size_t num_bytes = sizeof(FONSfont*) * (stash->cfonts - idx - 1);
+	memmove(dest, src, num_bytes);
+	stash->nfonts--;
+
+	return font;
+}
+
 int fonsAddFont(FONScontext* stash, const char* name, const char* path)
 {
 	FILE* fp = 0;

--- a/Processing_Sample/CProcessing/nanovg/src/fontstash.h
+++ b/Processing_Sample/CProcessing/nanovg/src/fontstash.h
@@ -885,8 +885,8 @@ static FONSfont* fons__remFont(FONScontext* stash, const char* name)
 
 	FONSfont* font = stash->fonts[idx];
 
-	FONSfont* dest = (FONSfont*)stash->fonts + (sizeof(FONSfont*) * idx);
-	FONSfont* src = dest + sizeof(FONSfont*);
+	char* dest = (char*)stash->fonts + (sizeof(FONSfont*) * idx);
+	char* src = dest + sizeof(FONSfont*);
 	size_t num_bytes = sizeof(FONSfont*) * (stash->cfonts - idx - 1);
 	memmove(dest, src, num_bytes);
 	stash->nfonts--;

--- a/Processing_Sample/CProcessing/nanovg/src/nanovg.c
+++ b/Processing_Sample/CProcessing/nanovg/src/nanovg.c
@@ -2398,6 +2398,11 @@ int nvgFindFont(NVGcontext* ctx, const char* name)
 	return fonsGetFontByName(ctx->fs, name);
 }
 
+void nvgFreeFont(NVGcontext* ctx, const char* name)
+{
+	FONSfont* font = fons__remFont(ctx->fs, name);
+	fons__freeFont(font);
+}
 
 int nvgAddFallbackFontId(NVGcontext* ctx, int baseFont, int fallbackFont)
 {

--- a/Processing_Sample/CProcessing/nanovg/src/nanovg.h
+++ b/Processing_Sample/CProcessing/nanovg/src/nanovg.h
@@ -599,6 +599,9 @@ int nvgCreateFontMem(NVGcontext* ctx, const char* name, unsigned char* data, int
 // Finds a loaded font of specified name, and returns handle to it, or -1 if the font is not found.
 int nvgFindFont(NVGcontext* ctx, const char* name);
 
+// Removes and frees a loaded font of a specified name
+void nvgFreeFont(NVGcontext* ctx, const char* name);
+
 // Adds a fallback font by handle.
 int nvgAddFallbackFontId(NVGcontext* ctx, int baseFont, int fallbackFont);
 


### PR DESCRIPTION
CP_Font_Free seems like it should be a simple task, but was quite complex.  There are three libraries at play.  CProcessing, NanoVG, and Fontstash all have a role in the allocating and management of fonts.  This fix plumbs function calls deep into NanoVG and Fontstash and improves management and cleanup internal to those libraries.

Now, users can load and free CP_Font using the same patterns as other assets (CP_Image and CP_Sound)
(There is also protection against freeing the built-in font so text functions will always have a font to use.)