### PR TITLE
BugFix - CP_Graphics_ClearBackground not always clearing the background

### DIFF
--- a/Processing_Sample/CProcessing/Source/CP_Graphics.c
+++ b/Processing_Sample/CProcessing/Source/CP_Graphics.c
@@ -92,6 +92,7 @@ static void CP_Graphics_DrawRectInternal(float x, float y, float w, float h, flo
 CP_API void CP_Graphics_ClearBackground(CP_Color c)
 {
 	// Set the background color
+	nvgCancelFrame(GetCPCore()->nvg);	// also wipe any prior render calls this frame
 	glClearColor(c.r / 255.0f, c.g / 255.0f, c.b / 255.0f, c.a / 255.0f);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 }


### PR DESCRIPTION
CP_Graphics_ClearBackground - This was just some odd behavior.  If the user made draw calls and then later in the same frame chose to clear the background, it wouldn't always clear fully.  This is not great programming since it wouldn't make much sense to perform a bunch of draw calls and then throw it all away with a clear, but it also doesn't make sense for the clear to not fully clear the buffer. Adding a CancelFrame call to ClearBackground doesn't cause issues during a normal frame and does reset the render queue if Clear is called mid to late in the update loop.