### PR TITLE
Add CW and CCW vector angle functions

### DIFF
--- a/Processing_Sample/CProcessing/Source/CP_Math.c
+++ b/Processing_Sample/CProcessing/Source/CP_Math.c
@@ -141,6 +141,28 @@ CP_API float CP_Vector_Angle(CP_Vector a, CP_Vector b)
 	return CP_Math_Degrees((float)acos((double)(CP_Vector_DotProduct(a, b) / (CP_Vector_Length(a) * CP_Vector_Length(b)))));
 }
 
+CP_API float CP_Vector_AngleCW(CP_Vector from, CP_Vector to)
+{
+	// update right vectors
+	CP_Vector toRight = CP_Vector_Set(-to.y, to.x);
+
+	float ang = CP_Vector_Angle(from, to);
+	if (CP_Vector_DotProduct(from, toRight) <= 0)
+	{
+		return ang;
+	}
+	else
+	{
+		return 360.0f - ang;
+	}
+}
+
+CP_API float CP_Vector_AngleCCW(CP_Vector from, CP_Vector to)
+{
+	float ang = CP_Vector_AngleCW(from, to);
+	return ang == 0 ? ang : ang - 360.0f;
+}
+
 //-------------------------------------
 // Matrix
 

--- a/Processing_Sample/CProcessing/inc/cprocessing.h
+++ b/Processing_Sample/CProcessing/inc/cprocessing.h
@@ -267,6 +267,8 @@ CP_API float			CP_Vector_Distance					(CP_Vector a, CP_Vector b);
 CP_API float			CP_Vector_DotProduct				(CP_Vector a, CP_Vector b);
 CP_API float			CP_Vector_CrossProduct				(CP_Vector a, CP_Vector b);
 CP_API float			CP_Vector_Angle						(CP_Vector a, CP_Vector b);
+CP_API float			CP_Vector_AngleCW					(CP_Vector from, CP_Vector to);
+CP_API float			CP_Vector_AngleCCW					(CP_Vector from, CP_Vector to);
 
 
 //---------------------------------------------------------


### PR DESCRIPTION
CP_Vector_AngleCW and CP_Vector_AngleCCW - This resolves ambiguity with the vector angle function.

AngleCW is always positive [0, 360.0)
AngleCCW is always negative [0, -360.0)

Notes: Internally this uses the existing angle function and only requires an additional dot product.  Also, if the vectors are the same, then both functions report an angle of 0 degrees.