### PR TITLE
Refresh Rate - added CP_System_GetDisplayRefreshRate and default FPS set to 60Hz

### DIFF
--- a/Processing_Sample/CProcessing/Source/CP_System.c
+++ b/Processing_Sample/CProcessing/Source/CP_System.c
@@ -40,8 +40,8 @@ FunctionPtr _postUpdateFunction = NULL;
 
 // FrameRate Control
 static double StartingTime, EndingTime, ElapsedSeconds;
-static double _frametimeTarget = 0.033333;
-static double _frametime = 0.033333;
+static double _frametimeTarget = 1.0 / 60.0;
+static double _frametime = 1.0 / 60.0;
 
 // Frames since the start of the program
 static unsigned int _frameCount;
@@ -224,6 +224,11 @@ CP_API int CP_System_GetDisplayWidth(void)
 CP_API int CP_System_GetDisplayHeight(void)
 {
 	return _CORE.native_height;
+}
+
+CP_API int CP_System_GetDisplayRefreshRate(void)
+{
+	return glfwGetVideoMode(glfwGetPrimaryMonitor())->refreshRate;
 }
 
 CP_API HWND CP_System_GetWindowHandle(void)

--- a/Processing_Sample/CProcessing/inc/cprocessing.h
+++ b/Processing_Sample/CProcessing/inc/cprocessing.h
@@ -72,6 +72,7 @@ CP_API int				CP_System_GetWindowWidth			(void);
 CP_API int				CP_System_GetWindowHeight			(void);
 CP_API int				CP_System_GetDisplayWidth			(void);
 CP_API int				CP_System_GetDisplayHeight			(void);
+CP_API int				CP_System_GetDisplayRefreshRate		(void);
 CP_API HWND				CP_System_GetWindowHandle			(void);
 CP_API void				CP_System_SetWindowTitle			(const char* title);
 CP_API CP_BOOL			CP_System_GetWindowFocus			(void);


### PR DESCRIPTION
Long time request to make CProcessing default to 60Hz.  With this update we also added the ability to request the display refresh rate so you can match the hardware.